### PR TITLE
feature(dashboard): agregar componente de tabla de archivos

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,12 +1,8 @@
 import StatsCard from '@/components/dashboard/StatsCard';
 import ChartContainer from '@/components/dashboard/ChartContainer';
-
-const cardData = [
-  { title: 'Unresolved', data: '60' },
-  { title: 'Overdue', data: '16' },
-  { title: 'Open', data: '43' },
-  { title: 'On hold', data: '64' },
-];
+import { FilesTable } from '@/components/table/FilesTable';
+import { columns } from '@/components/table/FilesTableColumn';
+import { cardData, filesData } from '@/data/dashboardStats';
 
 const DashboardPage = () => {
   return (
@@ -19,6 +15,7 @@ const DashboardPage = () => {
       <section>
         <ChartContainer />
       </section>
+      <FilesTable columns={columns} data={filesData} />
     </main>
   );
 };

--- a/src/components/table/FilesTable.tsx
+++ b/src/components/table/FilesTable.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { getCoreRowModel, useReactTable } from '@tanstack/react-table';
+import { Table } from '@/components/ui/table';
+import { DataTableProps } from '@/types/DataTable.types';
+import { FilesTableTitle } from '@/components/table/FilesTableTitle';
+import { FilesTableHeader } from '@/components/table/FilesTableHeader';
+import { FilesTableBody } from '@/components/table/FilesTableBody';
+
+export const FilesTable = <TData, TValue>({
+  columns,
+  data,
+}: DataTableProps<TData, TValue>) => {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <section className="font-inter rounded-lg border bg-white w-full">
+      <FilesTableTitle />
+      <div className="overflow-x-auto grid">
+        <Table>
+          <FilesTableHeader table={table} />
+          <FilesTableBody table={table} />
+        </Table>
+      </div>
+    </section>
+  );
+};

--- a/src/components/table/FilesTableBody.tsx
+++ b/src/components/table/FilesTableBody.tsx
@@ -1,0 +1,21 @@
+import { flexRender } from '@tanstack/react-table';
+import { TableBody, TableRow, TableCell } from '@/components/ui/table';
+import { DataTableHeaderBodyProps } from '@/types/DataTable.types';
+
+export const FilesTableBody = <TData,>({
+  table,
+}: DataTableHeaderBodyProps<TData>) => {
+  return (
+    <TableBody>
+      {table.getRowModel().rows.map((row) => (
+        <TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}>
+          {row.getVisibleCells().map((cell) => (
+            <TableCell key={cell.id}>
+              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+            </TableCell>
+          ))}
+        </TableRow>
+      ))}
+    </TableBody>
+  );
+};

--- a/src/components/table/FilesTableCell.tsx
+++ b/src/components/table/FilesTableCell.tsx
@@ -1,0 +1,49 @@
+import Image from 'next/image';
+import { Checkbox } from '@/components/ui/checkbox';
+import fileIcon from '@/images/icons/file-icon.svg';
+import imageIcon from '@/images/icons/image-icon.svg';
+import filmIcon from '@/images/icons/film-icon.svg';
+import figmaIcon from '@/images/icons/figma-icon.svg';
+import framerIcon from '@/images/icons/framer-icon.svg';
+import { Row, Table } from '@tanstack/react-table';
+import { Files } from '@/types/DataTable.types';
+
+const iconsFormat = {
+  pdf: fileIcon,
+  jpg: imageIcon,
+  png: imageIcon,
+  mp4: filmIcon,
+  fig: figmaIcon,
+  docx: fileIcon,
+  framerx: framerIcon,
+};
+
+export const TextCell = ({ value }: { value: string }) => (
+  <span className="text-[#667085] text-sm font-normal">{value}</span>
+);
+
+export const FilesTableFileNameHeader = ({ table }: { table: Table<Files> }) => {
+  return (
+    <div className="flex items-center gap-3">
+      <Checkbox checked={ table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && 'indeterminate') } onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)} aria-label="Select all" />
+      File name
+    </div>
+  );
+};
+
+export const FilesTableFileNameBody = ({ row }: { row: Row<Files> }) => {
+  const filename = row.getValue('filename') as string;
+  const filesize = row.getValue('filesize') as string;
+  return (
+    <div className="flex items-center gap-3">
+      <Checkbox checked={row.getIsSelected()} onCheckedChange={(value) => row.toggleSelected(!!value)} aria-label="Select row" />
+      <div className="bg-[#F4EBFF] p-2.5 rounded-full min-w-10">
+        <Image src={ iconsFormat[filename.split('.').pop() as keyof typeof iconsFormat] } alt={filename} width={20} height={20} />
+      </div>
+      <div>
+        <p className="text-sm font-medium">{filename}</p>
+        <span className="text-[#667085] text-sm font-normal">{filesize}</span>
+      </div>
+    </div>
+  );
+};

--- a/src/components/table/FilesTableColumn.tsx
+++ b/src/components/table/FilesTableColumn.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { ColumnDef } from '@tanstack/react-table';
+import { Button } from '../ui/button';
+import { MoreVerticalIcon } from 'lucide-react';
+import { Files } from '@/types/DataTable.types';
+import { FilesTableFileNameHeader, FilesTableFileNameBody, TextCell } from '@/components/table/FilesTableCell';
+
+export const columns: ColumnDef<Files>[] = [
+  {
+    accessorKey: 'filename',
+    header: ({ table }) => <FilesTableFileNameHeader table={table} />,
+    cell: ({ row }) => <FilesTableFileNameBody row={row} />,
+  },
+  {
+    accessorKey: 'filesize',
+    header: () => <div>File size</div>,
+    cell: ({ row }) => <TextCell value={row.getValue('filesize') as string} />,
+  },
+  {
+    accessorKey: 'dateuploaded',
+    header: () => <div>Date uploaded</div>,
+    cell: ({ row }) => (
+      <TextCell value={row.getValue('dateuploaded') as string} />
+    ),
+  },
+  {
+    accessorKey: 'lastupdated',
+    header: () => <div>Last updated</div>,
+    cell: ({ row }) => (
+      <TextCell value={row.getValue('lastupdated') as string} />
+    ),
+  },
+  {
+    accessorKey: 'uploadedby',
+    header: () => <div>Uploaded by</div>,
+    cell: ({ row }) => (
+      <TextCell value={row.getValue('uploadedby') as string} />
+    ),
+  },
+  {
+    id: 'actions',
+    cell: () => (
+      <Button variant="ghost" className="flex size-8 text-muted-foreground data-[state=open]:bg-muted cursor-pointer" size="icon" >
+        <MoreVerticalIcon />
+        <span className="sr-only">Open menu</span>
+      </Button>
+    ),
+  },
+];

--- a/src/components/table/FilesTableHeader.tsx
+++ b/src/components/table/FilesTableHeader.tsx
@@ -1,0 +1,28 @@
+import { flexRender } from '@tanstack/react-table';
+import { TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { DataTableHeaderBodyProps } from '@/types/DataTable.types';
+
+export const FilesTableHeader = <TData,>({
+  table,
+}: DataTableHeaderBodyProps<TData>) => {
+  return (
+    <TableHeader>
+      {table.getHeaderGroups().map((headerGroup) => (
+        <TableRow key={headerGroup.id}>
+          {headerGroup.headers.map((header) => {
+            return (
+              <TableHead key={header.id}>
+                {header.isPlaceholder
+                  ? null
+                  : flexRender(
+                      header.column.columnDef.header,
+                      header.getContext(),
+                    )}
+              </TableHead>
+            );
+          })}
+        </TableRow>
+      ))}
+    </TableHeader>
+  );
+};

--- a/src/components/table/FilesTableTitle.tsx
+++ b/src/components/table/FilesTableTitle.tsx
@@ -1,0 +1,20 @@
+import Image from 'next/image';
+import { Button } from '@/components/ui/button';
+import uploadIcon from '@/images/icons/upload-icon.svg';
+
+export const FilesTableTitle = () => {
+  return (
+    <div className="flex justify-between items-center py-5 px-6">
+      <h2 className="text-lg font-medium">Files uploaded</h2>
+      <div className="flex gap-3">
+        <Button variant="outline" className="py-[9px] px-4 text-gray-700">
+          <span className="leading-5 font-medium">Download all</span>
+        </Button>
+        <Button variant="purple" className="py-[9px] px-4 ">
+          <Image src={uploadIcon} alt="Upload" />
+          <span className="leading-5 font-medium">Upload</span>
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/data/dashboardStats.ts
+++ b/src/data/dashboardStats.ts
@@ -1,3 +1,12 @@
+import { Files } from '@/components/table/FilesTableColumn';
+
+export const cardData = [
+  { title: 'Unresolved', data: '60' },
+  { title: 'Overdue', data: '16' },
+  { title: 'Open', data: '43' },
+  { title: 'On hold', data: '64' },
+];
+
 export const statsData = [
   {
     title: 'Resolved',
@@ -18,5 +27,57 @@ export const statsData = [
   {
     title: 'Resolution within SLA',
     data: '94%',
+  },
+];
+
+export const filesData: Files[] = [
+  {
+    filename: 'Tech requirements.pdf',
+    filesize: '200 KB',
+    dateuploaded: 'Jan 4, 2022',
+    lastupdated: 'Jan 4, 2022',
+    uploadedby: 'Olivia Rhye',
+  },
+  {
+    filename: 'Dashboard screenshot.jpg',
+    filesize: '720 KB',
+    dateuploaded: 'Jan 4, 2022',
+    lastupdated: 'Jan 4, 2022',
+    uploadedby: 'Phoenix Baker',
+  },
+  {
+    filename: 'Dashboard prototype recording.mp4',
+    filesize: '16 MB',
+    dateuploaded: 'Jan 2, 2022',
+    lastupdated: 'Jan 2, 2022',
+    uploadedby: 'Lana Steiner',
+  },
+  {
+    filename: 'Dashboard prototype FINAL.fig',
+    filesize: '4.2 MB',
+    dateuploaded: 'Jan 6, 2022',
+    lastupdated: 'Jan 6, 2022',
+    uploadedby: 'Demi Wilkinson',
+  },
+  {
+    filename: 'UX Design Guidelines.docx',
+    filesize: '400 KB',
+    dateuploaded: 'Jan 8, 2022',
+    lastupdated: 'Jan 8, 2022',
+    uploadedby: 'Candice Wu',
+  },
+  {
+    filename: 'Dashboard interaction.framerx',
+    filesize: '12 MB',
+    dateuploaded: 'Jan 6, 2022',
+    lastupdated: 'Jan 6, 2022',
+    uploadedby: 'Natali Craig',
+  },
+  {
+    filename: 'App inspiration.png',
+    filesize: '800 KB',
+    dateuploaded: 'Jan 4, 2022',
+    lastupdated: 'Jan 4, 2022',
+    uploadedby: 'Drew Cano',
   },
 ];

--- a/src/types/DataTable.types.ts
+++ b/src/types/DataTable.types.ts
@@ -1,0 +1,19 @@
+import { ColumnDef, Table } from '@tanstack/react-table';
+
+export interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[];
+  data: TData[];
+}
+
+export interface DataTableHeaderBodyProps<TData> {
+  table: Table<TData>;
+}
+
+export type Files = {
+  filename: string;
+  filesize: string;
+  dateuploaded: string;
+  lastupdated: string;
+  uploadedby: string;
+  actions?: string;
+};


### PR DESCRIPTION
## 📄 Descripción
Este PR contiene el componente de la tabla de archivos.

## 🛠️ Cambios introducidos
- Agregar componentes necesarios para la tabla de archivos:
  - FilesTable
  - FilesTableTitle
  - FilesTableHeader
  - FilesTableBody
  - FilesTableColumn
  - FilesTableCell
- Agregar types necesarios
- Agregar información a mostrar necesaria

## 🔍 Cómo probar
1. `git checkout feature/dashboard-view && npm run dev`
2. Navegar a `/dashboard` 
3. Validar diseño con UI en Figma

## 📸 Screenshots 
Antes
![image](https://github.com/user-attachments/assets/1879ae49-673f-405c-8113-6147aca64b34)

Después
![image](https://github.com/user-attachments/assets/7e564ff8-1f39-4b22-b517-ab5593980dce)

## ✅ Checklist
- [ ] El código sigue el UI de Figma de forma adecuada
